### PR TITLE
Add Mochi MCP server implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # mochi-mcp
-MCP server for the Mochi flashcard app . Enables AI agents and tools like ChatGPT or Claude to read, create, and manage flashcards directly from your Mochi account.
+
+An [MCP](https://modelcontextprotocol.io/) server that connects AI agents to the [Mochi flashcard app](https://mochi.cards/).
+It exposes read-only tools by default so agents can safely explore decks and notes without mutating your data. Passing the
+`--allow-write` flag enables the write tools (create, update, delete).
+
+## Features
+
+- Lists decks as MCP resources and renders deck/note payloads when requested.
+- Read-only tools for listing decks and notes or fetching a specific deck/note.
+- Optional write tools (gated behind `--allow-write`) for creating, updating, and deleting decks or notes.
+- Configurable via environment variables with validation provided by Pydantic settings.
+
+## Installation
+
+Create a virtual environment and install the project with its dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+## Configuration
+
+Set the `MOCHI_API_KEY` environment variable with the API key found in your Mochi account. Optional overrides:
+
+- `MOCHI_BASE_URL` — change the API base URL (defaults to `https://api.mochi.cards/v1`).
+- `MOCHI_REQUEST_TIMEOUT` — change the HTTP timeout (seconds, defaults to `30`).
+
+You can also pass `--base-url` and `--timeout` via the CLI for ad-hoc overrides.
+
+## Running the server
+
+The entry point exposes an stdio MCP server:
+
+```bash
+mochi-mcp              # read-only mode (default)
+mochi-mcp --allow-write  # enable write tools
+```
+
+When write tools are enabled, the server marks destructive tools with appropriate annotations so capable agents
+understand the risk.
+
+## Development
+
+Run the unit test suite with `pytest`:
+
+```bash
+pytest
+```
+
+## Testing notes
+
+The test suite uses `httpx`'s mock transport to avoid making live network calls. This keeps tests deterministic and means
+you do not need a live Mochi API key to run them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mochi-mcp"
+version = "0.1.0"
+description = "MCP server for the Mochi flashcard app"
+authors = [
+  {name = "AI Assistant"}
+]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "httpx>=0.28.0",
+  "mcp[cli]>=1.21.0",
+  "pydantic>=2.12.0",
+  "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.4",
+  "pytest-asyncio>=1.3",
+]
+
+[project.scripts]
+mochi-mcp = "mochi_mcp.__main__:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-ra"

--- a/src/mochi_mcp/__init__.py
+++ b/src/mochi_mcp/__init__.py
@@ -1,0 +1,9 @@
+"""Mochi MCP server package."""
+
+from .config import MochiServerSettings
+from .server import create_server
+
+__all__ = [
+    "MochiServerSettings",
+    "create_server",
+]

--- a/src/mochi_mcp/__main__.py
+++ b/src/mochi_mcp/__main__.py
@@ -1,0 +1,91 @@
+"""Command line entry point for the Mochi MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from typing import Any
+
+from pydantic import ValidationError
+
+from .api import MochiClient, MochiAPIError
+from .config import MochiServerSettings
+from .server import create_server, run_server
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Mochi MCP server over stdio.")
+    parser.add_argument(
+        "--allow-write",
+        action="store_true",
+        help="Enable write tools (create/update/delete). Defaults to read-only mode.",
+    )
+    parser.add_argument(
+        "--base-url",
+        help="Override the Mochi API base URL (defaults to https://api.mochi.cards/v1).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="HTTP timeout in seconds for API requests.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR).",
+    )
+    return parser
+
+
+async def _async_main(args: argparse.Namespace) -> None:
+    try:
+        settings = MochiServerSettings()
+    except ValidationError as exc:
+        raise SystemExit(_format_validation_error(exc)) from exc
+
+    updates: dict[str, Any] = {}
+    if args.base_url:
+        updates["base_url"] = args.base_url
+    if args.timeout is not None:
+        updates["request_timeout"] = args.timeout
+    if updates:
+        settings = settings.model_copy(update=updates)
+    if args.allow_write:
+        settings = settings.with_write_enabled()
+
+    log_level = getattr(logging, str(args.log_level).upper(), logging.INFO)
+    logging.basicConfig(level=log_level, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    async with MochiClient(
+        settings.api_key,
+        base_url=str(settings.base_url),
+        timeout=settings.request_timeout,
+    ) as client:
+        server = create_server(client, read_only=settings.read_only)
+        await run_server(server)
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    messages = ["Configuration error:"]
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error.get("loc", []))
+        msg = error.get("msg", "Invalid value")
+        messages.append(f"  - {loc or 'value'}: {msg}")
+    return "\n".join(messages)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        asyncio.run(_async_main(args))
+    except MochiAPIError as exc:
+        logging.error("Mochi API error: %s", exc)
+        raise SystemExit(1) from exc
+    except KeyboardInterrupt:
+        logging.info("Shutting down Mochi MCP server")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mochi_mcp/api.py
+++ b/src/mochi_mcp/api.py
@@ -1,0 +1,208 @@
+"""HTTP client abstractions for interacting with the Mochi API."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping
+
+import httpx
+
+
+class MochiAPIError(RuntimeError):
+    """Raised when the Mochi API responds with an error."""
+
+
+@dataclass(slots=True)
+class PaginatedResult:
+    """Represents a paginated response from Mochi."""
+
+    items: list[dict[str, Any]]
+    next_cursor: str | None = None
+
+    def to_payload(self, collection_name: str) -> dict[str, Any]:
+        """Return a dictionary formatted for tool responses."""
+
+        payload: dict[str, Any] = {collection_name: self.items}
+        if self.next_cursor:
+            payload["nextCursor"] = self.next_cursor
+        return payload
+
+
+class MochiClient:
+    """Asynchronous client that wraps the Mochi REST API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = "https://api.mochi.cards/v1",
+        timeout: float = 30.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "X-API-Key": api_key,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "mochi-mcp/0.1.0",
+        }
+        self._client = client or httpx.AsyncClient(base_url=base_url, headers=headers, timeout=timeout)
+        if client is None:
+            self._owns_client = True
+            self._client.headers.update(headers)
+        else:
+            # Ensure caller provided the authentication headers.
+            for key, value in headers.items():
+                self._client.headers.setdefault(key, value)
+            self._owns_client = False
+
+    async def __aenter__(self) -> "MochiClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def list_decks(self, *, cursor: str | None = None, limit: int | None = None) -> PaginatedResult:
+        params: MutableMapping[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        if limit:
+            params["limit"] = limit
+        response = await self._request("GET", "/decks", params=params)
+        data = self._json(response)
+        return self._parse_paginated(data, "decks")
+
+    async def get_deck(self, deck_id: str) -> dict[str, Any]:
+        response = await self._request("GET", f"/decks/{deck_id}")
+        data = self._json(response)
+        return self._parse_item(data, "deck")
+
+    async def list_notes(
+        self,
+        *,
+        deck_id: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+        query: str | None = None,
+    ) -> PaginatedResult:
+        params: MutableMapping[str, Any] = {}
+        if deck_id:
+            params["deckId"] = deck_id
+        if cursor:
+            params["cursor"] = cursor
+        if limit:
+            params["limit"] = limit
+        if query:
+            params["query"] = query
+        response = await self._request("GET", "/notes", params=params)
+        data = self._json(response)
+        return self._parse_paginated(data, "notes")
+
+    async def get_note(self, note_id: str) -> dict[str, Any]:
+        response = await self._request("GET", f"/notes/{note_id}")
+        data = self._json(response)
+        return self._parse_item(data, "note")
+
+    async def create_deck(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        response = await self._request("POST", "/decks", json=payload)
+        return self._parse_item(self._json(response), "deck")
+
+    async def update_deck(self, deck_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        response = await self._request("PATCH", f"/decks/{deck_id}", json=payload)
+        return self._parse_item(self._json(response), "deck")
+
+    async def delete_deck(self, deck_id: str) -> None:
+        await self._request("DELETE", f"/decks/{deck_id}")
+
+    async def create_note(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        response = await self._request("POST", "/notes", json=payload)
+        return self._parse_item(self._json(response), "note")
+
+    async def update_note(self, note_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        response = await self._request("PATCH", f"/notes/{note_id}", json=payload)
+        return self._parse_item(self._json(response), "note")
+
+    async def delete_note(self, note_id: str) -> None:
+        await self._request("DELETE", f"/notes/{note_id}")
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            response = await self._client.request(method, path, **kwargs)
+        except httpx.HTTPError as exc:  # pragma: no cover - httpx ensures str(exc)
+            raise MochiAPIError(f"HTTP error communicating with Mochi: {exc}") from exc
+
+        if response.status_code >= 400:
+            message = self._extract_error_message(response)
+            raise MochiAPIError(message)
+
+        return response
+
+    @staticmethod
+    def _json(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except json.JSONDecodeError as exc:
+            raise MochiAPIError("Mochi API returned invalid JSON") from exc
+
+    @staticmethod
+    def _extract_error_message(response: httpx.Response) -> str:
+        try:
+            data = response.json()
+        except json.JSONDecodeError:
+            return f"Mochi API error {response.status_code}: {response.text.strip()}"
+
+        if isinstance(data, dict):
+            for key in ("message", "error", "detail"):
+                value = data.get(key)
+                if isinstance(value, str):
+                    return f"Mochi API error {response.status_code}: {value}"
+        return f"Mochi API error {response.status_code}"
+
+    @staticmethod
+    def _parse_paginated(data: Any, collection_name: str) -> PaginatedResult:
+        items: list[dict[str, Any]] = []
+        next_cursor: str | None = None
+
+        if isinstance(data, list):
+            items = [item for item in data if isinstance(item, Mapping)]  # type: ignore[list-item]
+            return PaginatedResult(items, None)
+
+        if isinstance(data, Mapping):
+            # Most API responses use a nested `data` object.
+            potential_container: Mapping[str, Any] = data
+            data_field = potential_container.get("data")
+            if isinstance(data_field, Mapping):
+                potential_container = data_field
+
+            if collection_name in potential_container and isinstance(potential_container[collection_name], list):
+                items = [item for item in potential_container[collection_name] if isinstance(item, Mapping)]
+            elif "items" in potential_container and isinstance(potential_container["items"], list):
+                items = [item for item in potential_container["items"] if isinstance(item, Mapping)]
+
+            cursor_value = potential_container.get("nextCursor") or potential_container.get("cursor")
+            if isinstance(cursor_value, str) and cursor_value:
+                next_cursor = cursor_value
+
+        return PaginatedResult(items, next_cursor)
+
+    @staticmethod
+    def _parse_item(data: Any, key: str) -> dict[str, Any]:
+        if isinstance(data, Mapping):
+            if key in data and isinstance(data[key], Mapping):
+                return dict(data[key])
+            data_field = data.get("data")
+            if isinstance(data_field, Mapping):
+                if key in data_field and isinstance(data_field[key], Mapping):
+                    return dict(data_field[key])
+                return dict(data_field)
+        if isinstance(data, Mapping):
+            return dict(data)
+        raise MochiAPIError("Unexpected response format from Mochi API")
+
+
+__all__ = ["MochiAPIError", "MochiClient", "PaginatedResult"]

--- a/src/mochi_mcp/config.py
+++ b/src/mochi_mcp/config.py
@@ -1,0 +1,46 @@
+"""Configuration helpers for the Mochi MCP server."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field, HttpUrl
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class MochiServerSettings(BaseSettings):
+    """Settings that control how the MCP server connects to Mochi."""
+
+    model_config = SettingsConfigDict(env_prefix="MOCHI_", env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    api_key: Annotated[str, Field(description="API key used to authenticate with Mochi.")]
+    base_url: Annotated[
+        HttpUrl,
+        Field(
+            default="https://api.mochi.cards/v1",
+            description="Base URL for the Mochi API.",
+        ),
+    ]
+    read_only: Annotated[
+        bool,
+        Field(
+            default=True,
+            description="When true the server only exposes read-only tools.",
+        ),
+    ]
+    request_timeout: Annotated[
+        float,
+        Field(
+            default=30.0,
+            description="HTTP timeout (seconds) for requests to the Mochi API.",
+            gt=0,
+        ),
+    ]
+
+    def with_write_enabled(self) -> "MochiServerSettings":
+        """Return a copy of the settings with write operations enabled."""
+
+        return self.model_copy(update={"read_only": False})
+
+
+__all__ = ["MochiServerSettings"]

--- a/src/mochi_mcp/server.py
+++ b/src/mochi_mcp/server.py
@@ -1,0 +1,431 @@
+"""Server wiring for the Mochi MCP integration."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from mcp import types
+from mcp.server import NotificationOptions, Server
+from mcp.server import stdio
+from mcp.server.lowlevel.helper_types import ReadResourceContents
+
+from .api import MochiAPIError, MochiClient
+
+LOGGER = logging.getLogger(__name__)
+
+_DECK_URI_PREFIX = "mochi://deck/"
+_MAX_DECK_RESOURCES = 500
+
+
+@dataclass(slots=True)
+class _ParsedResourceUri:
+    kind: str
+    identifier: str
+
+
+def create_server(client: MochiClient, *, read_only: bool = True) -> Server:
+    """Create and configure the MCP server."""
+
+    instructions = [
+        "Interact with the Mochi flashcard API through MCP tools.",
+        "The server authenticates with the API using the configured MOCHI_API_KEY.",
+    ]
+    if read_only:
+        instructions.append("Write operations are disabled; only read-only tools are available.")
+    else:
+        instructions.append("Write tools are enabled; use destructive operations carefully.")
+
+    server = Server(
+        name="mochi-mcp",
+        instructions="\n".join(instructions),
+        website_url="https://mochi.cards",
+    )
+
+    @server.list_resources()
+    async def list_resources() -> list[types.Resource]:
+        LOGGER.debug("Listing decks for resource catalog")
+        resources: list[types.Resource] = []
+        cursor: str | None = None
+
+        while True:
+            page = await client.list_decks(cursor=cursor, limit=200)
+            for deck in page.items:
+                if _deck_identifier(deck):
+                    resources.append(_deck_to_resource(deck))
+            if not page.next_cursor or len(resources) >= _MAX_DECK_RESOURCES:
+                break
+            cursor = page.next_cursor
+
+        return resources[:_MAX_DECK_RESOURCES]
+
+    @server.read_resource()
+    async def read_resource(uri: Any):
+        parsed = _parse_resource_uri(str(uri))
+        if parsed.kind == "deck":
+            payload = await client.get_deck(parsed.identifier)
+        elif parsed.kind == "note":
+            payload = await client.get_note(parsed.identifier)
+        else:  # pragma: no cover - guarded by parser
+            raise ValueError(f"Unsupported resource URI: {uri}")
+        content = json.dumps(payload, indent=2, sort_keys=True)
+        return [ReadResourceContents(content=content, mime_type="application/json")]
+
+    @server.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        tools: list[types.Tool] = [
+            _tool_definition(
+                "list_decks",
+                "List decks from the authenticated Mochi workspace.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "description": "Maximum number of decks to return.",
+                        },
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor returned by a previous list_decks call.",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            ),
+            _tool_definition(
+                "get_deck",
+                "Fetch metadata about a single deck by identifier.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "deck_id": {
+                            "type": "string",
+                            "description": "Deck identifier (id or slug).",
+                        }
+                    },
+                    "required": ["deck_id"],
+                    "additionalProperties": False,
+                },
+            ),
+            _tool_definition(
+                "list_notes",
+                "List notes/cards from Mochi. Optionally scope to a deck or search query.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "deck_id": {
+                            "type": "string",
+                            "description": "Only return notes that belong to this deck.",
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": "Full text search term.",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "description": "Maximum number of notes to return.",
+                        },
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor returned by a previous list_notes call.",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            ),
+            _tool_definition(
+                "get_note",
+                "Fetch a single note/card by identifier.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "note_id": {
+                            "type": "string",
+                            "description": "Note identifier.",
+                        }
+                    },
+                    "required": ["note_id"],
+                    "additionalProperties": False,
+                },
+            ),
+        ]
+
+        if not read_only:
+            tools.extend(
+                [
+                    _tool_definition(
+                        "create_deck",
+                        "Create a new deck in Mochi.",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string", "description": "Name of the deck."},
+                                "description": {
+                                    "type": "string",
+                                    "description": "Optional deck description.",
+                                },
+                                "parent_deck_id": {
+                                    "type": "string",
+                                    "description": "Optional parent deck identifier.",
+                                },
+                                "fields": {
+                                    "type": "object",
+                                    "description": "Additional raw fields to merge into the request body.",
+                                },
+                            },
+                            "required": ["name"],
+                            "additionalProperties": False,
+                        },
+                        annotations=types.ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+                    ),
+                    _tool_definition(
+                        "update_deck",
+                        "Update fields on an existing deck.",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "deck_id": {"type": "string", "description": "Deck identifier."},
+                                "fields": {
+                                    "type": "object",
+                                    "description": "Fields to update on the deck payload.",
+                                },
+                            },
+                            "required": ["deck_id", "fields"],
+                            "additionalProperties": False,
+                        },
+                        annotations=types.ToolAnnotations(readOnlyHint=False),
+                    ),
+                    _tool_definition(
+                        "delete_deck",
+                        "Delete a deck and its notes.",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "deck_id": {"type": "string", "description": "Deck identifier."}
+                            },
+                            "required": ["deck_id"],
+                            "additionalProperties": False,
+                        },
+                        annotations=types.ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+                    ),
+                    _tool_definition(
+                        "create_note",
+                        "Create a new note/card in Mochi.",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "deck_id": {"type": "string", "description": "Deck to add the note to."},
+                                "fields": {
+                                    "type": "object",
+                                    "description": "Payload describing the note fields (front/back, etc).",
+                                },
+                            },
+                            "required": ["deck_id", "fields"],
+                            "additionalProperties": False,
+                        },
+                        annotations=types.ToolAnnotations(readOnlyHint=False),
+                    ),
+                    _tool_definition(
+                        "update_note",
+                        "Update an existing note/card.",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "note_id": {"type": "string", "description": "Note identifier."},
+                                "fields": {
+                                    "type": "object", "description": "Fields to update on the note."},
+                            },
+                            "required": ["note_id", "fields"],
+                            "additionalProperties": False,
+                        },
+                        annotations=types.ToolAnnotations(readOnlyHint=False),
+                    ),
+                    _tool_definition(
+                        "delete_note",
+                        "Delete a note/card.",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "note_id": {"type": "string", "description": "Note identifier."}
+                            },
+                            "required": ["note_id"],
+                            "additionalProperties": False,
+                        },
+                        annotations=types.ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+                    ),
+                ]
+            )
+
+        return tools
+
+    @server.call_tool()
+    async def call_tool(tool_name: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        match tool_name:
+            case "list_decks":
+                result = await client.list_decks(
+                    cursor=_optional_str(arguments.get("cursor")),
+                    limit=_optional_int(arguments.get("limit")),
+                )
+                return result.to_payload("decks")
+            case "get_deck":
+                deck_id = _require_str(arguments, "deck_id")
+                deck = await client.get_deck(deck_id)
+                return {"deck": deck}
+            case "list_notes":
+                result = await client.list_notes(
+                    deck_id=_optional_str(arguments.get("deck_id")),
+                    cursor=_optional_str(arguments.get("cursor")),
+                    limit=_optional_int(arguments.get("limit")),
+                    query=_optional_str(arguments.get("query")),
+                )
+                return result.to_payload("notes")
+            case "get_note":
+                note_id = _require_str(arguments, "note_id")
+                note = await client.get_note(note_id)
+                return {"note": note}
+
+        if read_only:
+            raise MochiAPIError(f"Unknown tool: {tool_name}")
+
+        match tool_name:
+            case "create_deck":
+                payload = {
+                    "name": _require_str(arguments, "name"),
+                }
+                if description := _optional_str(arguments.get("description")):
+                    payload["description"] = description
+                if parent := _optional_str(arguments.get("parent_deck_id")):
+                    payload["parentDeckId"] = parent
+                if "fields" in arguments:
+                    payload.update(_require_mapping(arguments, "fields"))
+                deck = await client.create_deck(payload)
+                return {"deck": deck}
+            case "update_deck":
+                deck_id = _require_str(arguments, "deck_id")
+                fields = _require_mapping(arguments, "fields")
+                deck = await client.update_deck(deck_id, fields)
+                return {"deck": deck}
+            case "delete_deck":
+                deck_id = _require_str(arguments, "deck_id")
+                await client.delete_deck(deck_id)
+                return {"status": "deleted", "deck_id": deck_id}
+            case "create_note":
+                deck_id = _require_str(arguments, "deck_id")
+                fields = _require_mapping(arguments, "fields")
+                payload = dict(fields)
+                payload["deckId"] = deck_id
+                note = await client.create_note(payload)
+                return {"note": note}
+            case "update_note":
+                note_id = _require_str(arguments, "note_id")
+                fields = _require_mapping(arguments, "fields")
+                note = await client.update_note(note_id, fields)
+                return {"note": note}
+            case "delete_note":
+                note_id = _require_str(arguments, "note_id")
+                await client.delete_note(note_id)
+                return {"status": "deleted", "note_id": note_id}
+
+        raise MochiAPIError(f"Unknown tool: {tool_name}")
+
+    return server
+
+
+async def run_server(server: Server) -> None:
+    """Run the server over stdio."""
+
+    initialization_options = server.create_initialization_options(NotificationOptions())
+    async with stdio.stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, initialization_options)
+
+
+def _deck_identifier(deck: Mapping[str, Any]) -> str | None:
+    for key in ("id", "uuid", "slug"):
+        value = deck.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, int):
+            return str(value)
+    return None
+
+
+def _deck_to_resource(deck: Mapping[str, Any]) -> types.Resource:
+    identifier = _deck_identifier(deck)
+    if not identifier:
+        raise MochiAPIError("Deck payload is missing an identifier")
+    name = str(deck.get("name") or deck.get("title") or identifier)
+    description = deck.get("description")
+    annotations = types.Annotations(priority=0.5) if description else None
+    return types.Resource(
+        name=name,
+        uri=f"{_DECK_URI_PREFIX}{identifier}",
+        description=str(description) if isinstance(description, str) else None,
+        annotations=annotations,
+    )
+
+
+def _parse_resource_uri(uri: str) -> _ParsedResourceUri:
+    parsed = urlparse(uri)
+    if parsed.scheme != "mochi" or not parsed.netloc:
+        raise ValueError(f"Unsupported Mochi resource URI: {uri}")
+    identifier = parsed.path.lstrip("/")
+    if not identifier:
+        raise ValueError(f"Missing identifier in resource URI: {uri}")
+    return _ParsedResourceUri(kind=parsed.netloc, identifier=identifier)
+
+
+def _optional_str(value: Any) -> str | None:
+    return str(value) if isinstance(value, (str, int)) and value != "" else None
+
+
+def _optional_int(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Expected integer, received {value!r}") from exc
+    return None
+
+
+def _require_str(arguments: Mapping[str, Any], field: str) -> str:
+    value = arguments.get(field)
+    if isinstance(value, str) and value:
+        return value
+    if isinstance(value, int):
+        return str(value)
+    raise ValueError(f"Field '{field}' is required and must be a string")
+
+
+def _require_mapping(arguments: Mapping[str, Any], field: str) -> dict[str, Any]:
+    value = arguments.get(field)
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise ValueError(f"Field '{field}' must be an object containing fields to send to Mochi")
+
+
+def _tool_definition(
+    name: str,
+    description: str,
+    input_schema: Mapping[str, Any],
+    *,
+    annotations: types.ToolAnnotations | None = None,
+) -> types.Tool:
+    annotations = annotations or types.ToolAnnotations(readOnlyHint=True)
+    return types.Tool(
+        name=name,
+        description=description,
+        inputSchema=dict(input_schema),
+        annotations=annotations,
+    )
+
+
+__all__ = ["create_server", "run_server"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from mochi_mcp.api import MochiAPIError, MochiClient
+
+
+@pytest.mark.asyncio
+async def test_list_decks_parses_paginated_response() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/decks"
+        assert request.headers["Authorization"] == "Bearer secret"
+        assert request.headers["X-API-Key"] == "secret"
+        assert request.url.params["limit"] == "50"
+        assert request.url.params["cursor"] == "abc"
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "decks": [
+                        {"id": "deck-1", "name": "My Deck"},
+                    ],
+                    "cursor": "next-cursor",
+                }
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as http_client:
+        async with MochiClient("secret", base_url="https://example.test", client=http_client) as client:
+            result = await client.list_decks(limit=50, cursor="abc")
+    assert result.items == [{"id": "deck-1", "name": "My Deck"}]
+    assert result.next_cursor == "next-cursor"
+
+
+@pytest.mark.asyncio
+async def test_get_note_handles_nested_payload() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/notes/note-1"
+        return httpx.Response(200, json={"data": {"note": {"id": "note-1", "front": "Hello"}}})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as http_client:
+        async with MochiClient("secret", base_url="https://example.test", client=http_client) as client:
+            note = await client.get_note("note-1")
+    assert note == {"id": "note-1", "front": "Hello"}
+
+
+@pytest.mark.asyncio
+async def test_delete_note_allows_no_content_response() -> None:
+    calls: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        return httpx.Response(204)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as http_client:
+        async with MochiClient("secret", base_url="https://example.test", client=http_client) as client:
+            await client.delete_note("note-1")
+    assert calls == ["/notes/note-1"]
+
+
+@pytest.mark.asyncio
+async def test_client_raises_for_error_status() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "Not Found"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as http_client:
+        async with MochiClient("secret", base_url="https://example.test", client=http_client) as client:
+            with pytest.raises(MochiAPIError) as excinfo:
+                await client.get_deck("missing")
+    assert "404" in str(excinfo.value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from mcp import types
+
+from mochi_mcp.api import PaginatedResult
+from mochi_mcp.server import create_server
+
+
+@dataclass
+class FakeMochiClient:
+    decks: list[dict[str, Any]] = field(default_factory=lambda: [{"id": "deck-1", "name": "Deck One"}])
+    notes: dict[str, dict[str, Any]] = field(
+        default_factory=lambda: {
+            "note-1": {"id": "note-1", "deckId": "deck-1", "front": "hello"},
+            "note-2": {"id": "note-2", "deckId": "deck-2", "front": "world"},
+        }
+    )
+    created_notes: list[dict[str, Any]] = field(default_factory=list)
+    updated_notes: list[dict[str, Any]] = field(default_factory=list)
+    deleted_notes: list[str] = field(default_factory=list)
+    deleted_decks: list[str] = field(default_factory=list)
+
+    async def list_decks(self, *, cursor: str | None = None, limit: int | None = None) -> PaginatedResult:
+        return PaginatedResult(self.decks[: limit or len(self.decks)], None)
+
+    async def get_deck(self, deck_id: str) -> dict[str, Any]:
+        for deck in self.decks:
+            if deck["id"] == deck_id:
+                return deck
+        return {"id": deck_id}
+
+    async def list_notes(
+        self,
+        *,
+        deck_id: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+        query: str | None = None,
+    ) -> PaginatedResult:
+        filtered = [note for note in self.notes.values() if deck_id is None or note.get("deckId") == deck_id]
+        if query:
+            filtered = [note for note in filtered if query.lower() in str(note).lower()]
+        return PaginatedResult(filtered[: limit or len(filtered)], None)
+
+    async def get_note(self, note_id: str) -> dict[str, Any]:
+        return self.notes[note_id]
+
+    async def create_deck(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        new_deck = {"id": payload.get("name", "deck-new"), **payload}
+        self.decks.append(new_deck)
+        return new_deck
+
+    async def update_deck(self, deck_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        deck = await self.get_deck(deck_id)
+        deck.update(payload)
+        return deck
+
+    async def delete_deck(self, deck_id: str) -> None:
+        self.deleted_decks.append(deck_id)
+
+    async def create_note(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        note_id = payload.get("id", f"generated-{len(self.created_notes)}")
+        note = {"id": note_id, **payload}
+        self.created_notes.append(note)
+        self.notes[note_id] = note
+        return note
+
+    async def update_note(self, note_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        note = self.notes[note_id]
+        note.update(payload)
+        self.updated_notes.append({"note_id": note_id, **payload})
+        return note
+
+    async def delete_note(self, note_id: str) -> None:
+        self.deleted_notes.append(note_id)
+        self.notes.pop(note_id, None)
+
+
+@pytest.mark.asyncio
+async def test_read_only_tools_exposed() -> None:
+    server = create_server(FakeMochiClient(), read_only=True)
+    result = await server.request_handlers[types.ListToolsRequest](types.ListToolsRequest())
+    tool_names = {tool.name for tool in result.root.tools}
+    assert {"list_decks", "get_deck", "list_notes", "get_note"} <= tool_names
+    assert "delete_note" not in tool_names
+
+
+@pytest.mark.asyncio
+async def test_write_tools_available_when_enabled() -> None:
+    server = create_server(FakeMochiClient(), read_only=False)
+    result = await server.request_handlers[types.ListToolsRequest](types.ListToolsRequest())
+    tool_names = {tool.name for tool in result.root.tools}
+    assert "delete_note" in tool_names
+    assert "create_deck" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_call_tool_list_notes_filters_by_deck() -> None:
+    client = FakeMochiClient()
+    server = create_server(client, read_only=True)
+    req = types.CallToolRequest(
+        params=types.CallToolRequestParams(name="list_notes", arguments={"deck_id": "deck-1"})
+    )
+    result = await server.request_handlers[types.CallToolRequest](req)
+    structured = result.root.structuredContent
+    assert structured is not None
+    assert {note["id"] for note in structured["notes"]} == {"note-1"}
+
+
+@pytest.mark.asyncio
+async def test_write_tool_delete_note_records_action() -> None:
+    client = FakeMochiClient()
+    server = create_server(client, read_only=False)
+    req = types.CallToolRequest(
+        params=types.CallToolRequestParams(name="delete_note", arguments={"note_id": "note-1"})
+    )
+    result = await server.request_handlers[types.CallToolRequest](req)
+    assert result.root.structuredContent == {"status": "deleted", "note_id": "note-1"}
+    assert client.deleted_notes == ["note-1"]
+
+
+@pytest.mark.asyncio
+async def test_read_resource_returns_json() -> None:
+    client = FakeMochiClient()
+    server = create_server(client, read_only=True)
+    req = types.ReadResourceRequest(params=types.ReadResourceRequestParams(uri="mochi://deck/deck-1"))
+    result = await server.request_handlers[types.ReadResourceRequest](req)
+    text = result.root.contents[0].text
+    assert "deck-1" in text


### PR DESCRIPTION
## Summary
- add an async Mochi API client and settings helpers for the MCP server
- expose read-only MCP tools and optional write operations behind a CLI flag
- document setup and add unit tests for the client and server behaviour

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691484daa2bc8325a53ba6da5661c7aa)